### PR TITLE
Impersonation improvements

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -529,7 +529,7 @@ class User extends UserBase
      * Only backend users with the `winter.users.impersonate_user` permission are allowed to impersonate
      * users.
      *
-     * @param static|false $impersonator The user attempting to impersonate this user, false when not available
+     * @param \Winter\Storm\Auth\Models\User|false $impersonator The user attempting to impersonate this user, false when not available
      * @return boolean
      */
     public function canBeImpersonated($impersonator = false)

--- a/models/User.php
+++ b/models/User.php
@@ -534,7 +534,7 @@ class User extends UserBase
      */
     public function canBeImpersonated($impersonator = false)
     {
-        $user = BackendAuth::user();
+        $user = BackendAuth::getUser();
         if (!$user || !$user->hasAccess('winter.users.impersonate_user')) {
             return false;
         }

--- a/models/User.php
+++ b/models/User.php
@@ -5,6 +5,7 @@ use Auth;
 use Mail;
 use Event;
 use Config;
+use BackendAuth;
 use Carbon\Carbon;
 use Winter\Storm\Auth\Models\User as UserBase;
 use Winter\User\Models\Settings as UserSettings;
@@ -55,7 +56,7 @@ class User extends UserBase
         'created_ip_address',
         'last_ip_address'
     ];
-    
+
     /**
      * Reset guarded fields, because we use $fillable instead.
      * @var array The attributes that aren't mass assignable.
@@ -517,5 +518,27 @@ class User extends UserBase
     protected function generatePassword()
     {
         $this->password = $this->password_confirmation = Str::random(static::getMinPasswordLength());
+    }
+
+    //
+    // Impersonation
+    //
+
+    /**
+     * Check if this user can be impersonated by the provided impersonator
+     * Only backend users with the `winter.users.impersonate_user` permission are allowed to impersonate
+     * users.
+     *
+     * @param static|false $impersonator The user attempting to impersonate this user, false when not available
+     * @return boolean
+     */
+    public function canBeImpersonated($impersonator = false)
+    {
+        $user = BackendAuth::user();
+        if (!$user || !$user->hasAccess('winter.users.impersonate_user')) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
See wintercms/storm#47 for more details.

Todo:
- [ ] Change session component methods to return the backend user (because backend users are the only users permitted to impersonate frontend users thus Auth::getImpersonator() will return false)
- [ ] Provide example in default markup to identify when a user is being impersonated
- [ ] Add integration tests for the authentication system