### PR TITLE
Add onRemoveAvatar handler to account component

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -445,8 +445,8 @@ class Account extends ComponentBase
     }
 
     /**
-     * Remove user's avatar
-     * Supports deferred bindings using _session_key field
+     * Remove the user's avatar
+     * Will also unset avatars set via deferred binding if the  _session_key field is present in the POST data
      */
     public function onRemoveAvatar()
     {
@@ -458,9 +458,8 @@ class Account extends ComponentBase
 
         $this->prepareVars();
 
-        // Because avatar unbinding may be deferred,
-        // the avatar relationship may be reloaded using User::getAvatarThumb
-        // Set avatar relation to null
+        // Force the avatar relationship to be removed even if User::getAvatarThumb()
+        // has stale references
         $this->page['user']->setRelation('avatar', null);
     }
 

--- a/components/Account.php
+++ b/components/Account.php
@@ -445,6 +445,26 @@ class Account extends ComponentBase
     }
 
     /**
+     * Remove user's avatar
+     * Supports deferred bindings using _session_key field
+     */
+    public function onRemoveAvatar()
+    {
+        if (!$user = $this->user()) {
+            return;
+        }
+
+        $user->avatar()->remove($user->avatar, post('_session_key'));
+
+        $this->prepareVars();
+
+        // Because avatar unbinding may be deferred,
+        // the avatar relationship may be reloaded using User::getAvatarThumb
+        // Set avatar relation to null
+        $this->page['user']->setRelation('avatar', null);
+    }
+
+    /**
      * Deactivate user
      */
     public function onDeactivate()


### PR DESCRIPTION
Before this PR, there is no way at the component level to unset the avatar and get back to the default gravatar.

This allows to create advanced UX to unset the avatar relationship:
[unload-avatar.webm](https://user-images.githubusercontent.com/53976837/192506914-a95f7b08-e9cf-4ecf-b615-78c6ef4f2d25.webm)