### PR TITLE
Add avatar removal

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -445,6 +445,36 @@ class Account extends ComponentBase
     }
 
     /**
+     * Removes the user's avatar if available.
+     *
+     * This will remove the user's avatar and default back to the Gravatar attached to the user's
+     * email address.
+     *
+     * @return void
+     */
+    public function onRemoveAvatar()
+    {
+        if (!$user = $this->user()) {
+            return;
+        }
+
+        if (!$user->avatar) {
+            Flash::info(Lang::get(/*Settings successfully saved!*/'winter.user::lang.account.no_avatar'));
+            return;
+        }
+
+        $user->avatar()->remove($user->avatar);
+
+        Flash::success(Lang::get(/*Settings successfully saved!*/'winter.user::lang.account.avatar_removed'));
+
+        $this->prepareVars();
+
+        // Force the avatar relationship to be removed even if User::getAvatarThumb()
+        // has stale references
+        $this->page['user']->setRelation('avatar', null);
+    }
+
+    /**
      * Deactivate user
      */
     public function onDeactivate()

--- a/components/account/deactivate_link.htm
+++ b/components/account/deactivate_link.htm
@@ -7,17 +7,17 @@ function toggleAccountDeactivateForm() {
 
 <a
     href="javascript:;"
-    onclick="toggleAccountDeactivateForm()">
+    onclick="toggleAccountDeactivateForm()"
+    class="deactivate"
+>
     Deactivate account
 </a>
 
 <div id="accountDeactivateForm" style="display: none">
     {{ form_ajax('onDeactivate') }}
-        <hr />
         <h3>Deactivate your account?</h3>
         <p>
-            Your account will be disabled and your details removed from the site.
-            You can reactivate your account any time by signing back in.
+            Your account will be disabled and your details removed from the site. You can reactivate your account any time by signing back in.
         </p>
         <div class="form-group">
             <label for="accountDeletePassword">To continue, please enter your password:</label>

--- a/components/account/default.htm
+++ b/components/account/default.htm
@@ -3,7 +3,6 @@
     <div class="row">
 
         <div class="col-md-6">
-            <h3>Sign in</h3>
             {% partial __SELF__ ~ '::signin' %}
         </div>
 

--- a/components/account/signin.htm
+++ b/components/account/signin.htm
@@ -1,5 +1,6 @@
-{{ form_ajax('onSignin') }}
+<h3>Sign in</h3>
 
+{{ form_ajax('onSignin') }}
     <div class="form-group">
         <label for="userSigninLogin">{{ loginAttributeLabel }}</label>
         <input

--- a/components/account/update.htm
+++ b/components/account/update.htm
@@ -1,4 +1,6 @@
-{{ form_ajax('onUpdate') }}
+<h3>Profile</h3>
+
+{{ form_ajax('onUpdate', { flash: 1 }) }}
 
     <div class="form-group">
         <label for="accountName">Full Name</label>
@@ -18,6 +20,24 @@
     <div class="form-group">
         <label for="accountPasswordConfirm">Confirm New Password</label>
         <input name="password_confirmation" type="password" class="form-control" id="accountPasswordConfirm">
+    </div>
+
+    <div class="form-group">
+        <label for="accountAvatar">Display Picture</label>
+        <input
+            name="avatar"
+            type="file"
+            class="form-control"
+            id="accountAvatar"
+            accept="image/jpg, image/jpeg, image/png, image/gif, image/webp"
+            capture="user"
+        >
+
+        {% if user.avatar %}
+            <a href="javascript:;" data-request="onRemoveAvatar" data-request-flash class="remove-avatar">
+                Remove current display picture
+            </a>
+        {% endif %}
     </div>
 
     {% if updateRequiresPassword %}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -197,7 +197,9 @@ return [
         'new_password' => 'New Password',
         'new_password_confirm' => 'Confirm New Password',
         'update_requires_password' => 'Confirm password on update',
-        'update_requires_password_comment' => 'Require the current password of the user when changing their profile.'
+        'update_requires_password_comment' => 'Require the current password of the user when changing their profile.',
+        'no_avatar' => 'Your account has no display picture to remove.',
+        'avatar_removed' => 'Your display picture has been successfully removed.',
     ],
     'reset_password' => [
         'reset_password' => 'Reset Password',


### PR DESCRIPTION
Replaces https://github.com/wintercms/wn-user-plugin/pull/24.

This adds avatar removal to the Accounts component, and updates the default partials to include an avatar upload field and link to remove the avatar.

I've also made some slight tweaks to the default partials for consistency.

Credit to @RomainMazB for the initial implementation.