### PR TITLE
Allow reset password to activate user if user activation enabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,9 +86,9 @@ jobs:
 
       - name: Run unit tests (1.2/develop)
         if: matrix.winterRelease != 'v1.1.9'
-        run: php artisan winter:test -p Winter.User
+        run: php artisan winter:test -p Winter.User -- --testdox
 
       - name: Run unit tests (1.1)
         if: matrix.winterRelease == 'v1.1.9'
         working-directory: plugins/winter/user
-        run: ../../../vendor/bin/phpunit --bootstrap ../../../tests/bootstrap.php
+        run: ../../../vendor/bin/phpunit --bootstrap ../../../tests/bootstrap.php --testdox

--- a/models/User.php
+++ b/models/User.php
@@ -107,6 +107,31 @@ class User extends UserBase
     }
 
     /**
+     * Attempts to reset a user's password by matching the reset code generated with the user's.
+     *
+     * If user activation is enabled, the user will be activated as well.
+     *
+     * @param string $resetCode
+     * @param string $newPassword
+     * @return bool
+     */
+    public function attemptResetPassword($resetCode, $newPassword)
+    {
+        if (!parent::attemptResetPassword($resetCode, $newPassword)) {
+            return false;
+        }
+
+        if ($this->isActivatedByUser()) {
+            $this->activation_code = null;
+            $this->is_activated = true;
+            $this->activated_at = $this->freshTimestamp();
+            $this->forceSave();
+        }
+
+        return true;
+    }
+
+    /**
      * Converts a guest user to a registered one and sends an invitation notification.
      * @return void
      */
@@ -540,5 +565,13 @@ class User extends UserBase
         }
 
         return true;
+    }
+
+    /**
+     * Determines if activation is done by the user.
+     */
+    public function isActivatedByUser(): bool
+    {
+        return (UserSettings::get('activate_mode') === UserSettings::ACTIVATE_USER);
     }
 }

--- a/tests/UserPluginTestCase.php
+++ b/tests/UserPluginTestCase.php
@@ -4,17 +4,7 @@ use App;
 use Illuminate\Foundation\AliasLoader;
 use Winter\User\Models\Settings;
 
-if (class_exists('System\Tests\Bootstrap\PluginTestCase')) {
-    class BaseTestCase extends \System\Tests\Bootstrap\PluginTestCase
-    {
-    }
-} else {
-    class BaseTestCase extends \PluginTestCase
-    {
-    }
-}
-
-abstract class UserPluginTestCase extends BaseTestCase
+abstract class UserPluginTestCase extends \PluginTestCase
 {
     /**
      * @var array   Plugins to refresh between tests.
@@ -41,7 +31,7 @@ abstract class UserPluginTestCase extends BaseTestCase
         // register the auth facade
         $alias = AliasLoader::getInstance();
         $alias->alias('Auth', 'Winter\User\Facades\Auth');
-    
+
         App::singleton('user.auth', function () {
             return \Winter\User\Classes\AuthManager::instance();
         });

--- a/tests/unit/facades/AuthFacadeTest.php
+++ b/tests/unit/facades/AuthFacadeTest.php
@@ -1,4 +1,6 @@
-<?php namespace Winter\User\Tests\Unit\Facades;
+<?php
+
+namespace Winter\User\Tests\Unit\Facades;
 
 use Auth;
 use Winter\User\Models\User;
@@ -6,7 +8,7 @@ use Winter\User\Tests\UserPluginTestCase;
 
 class AuthFacadeTest extends UserPluginTestCase
 {
-    public function testRegisteringAUser()
+    public function testCanRegisterAUser()
     {
         // register a user
         $user = Auth::register([
@@ -19,14 +21,14 @@ class AuthFacadeTest extends UserPluginTestCase
         // our one user should be returned
         $this->assertEquals(1, User::count());
         $this->assertInstanceOf('Winter\User\Models\User', $user);
-        
+
         // and that user should have the following data
         $this->assertFalse($user->is_activated);
         $this->assertEquals('Some User', $user->name);
         $this->assertEquals('some@website.tld', $user->email);
     }
 
-    public function testRegisteringAUserWithAutoActivation()
+    public function testCanRegisterAndAutomaticallyActivateAUser()
     {
         // register a user with the auto-activate flag
         $user = Auth::register([
@@ -43,7 +45,7 @@ class AuthFacadeTest extends UserPluginTestCase
         $this->assertTrue(Auth::check());
     }
 
-    public function testRegisteringAGuest()
+    public function testCanRegisterAGuest()
     {
         // register a guest
         $guest = Auth::registerGuest(['email' => 'person@acme.tld']);
@@ -57,7 +59,7 @@ class AuthFacadeTest extends UserPluginTestCase
         $this->assertEquals('person@acme.tld', $guest->email);
     }
 
-    public function testLoginAndCheckingAuthentication()
+    public function testCanLoginAndCheckAuthenticationAndActivation()
     {
         // we should not be authenticated
         $this->assertFalse(Auth::check());

--- a/tests/unit/models/UserModelTest.php
+++ b/tests/unit/models/UserModelTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Winter\User\Tests\Unit\Models;
+
+use Mockery;
+use Winter\User\Models\User;
+use Winter\User\Tests\UserPluginTestCase;
+
+class UserModelTest extends UserPluginTestCase
+{
+    public function testCanActivateUserOnPasswordResetIfUserActivationEnabled()
+    {
+        $userMock = Mockery::mock(User::class)->makePartial();
+        $userMock->shouldReceive('isActivatedByUser')->andReturn(true);
+        $userMock->shouldReceive('flushEventListeners')->andReturnNull();
+
+        $userMock->fill([
+            'name' => 'Some User',
+            'email' => 'some@website.tld',
+            'password' => 'changeme',
+        ]);
+        $userMock->reset_password_code = '12345abcde';
+        $userMock->save();
+
+        // Attempt a password reset
+        $this->assertTrue($userMock->attemptResetPassword('12345abcde', 'newpassword'));
+        $this->assertTrue($userMock->is_activated);
+    }
+
+    public function testWontActivateUserOnPasswordResetIfUserActivationNotEnabled()
+    {
+        $userMock = Mockery::mock(User::class)->makePartial();
+        $userMock->shouldReceive('isActivatedByUser')->andReturn(false);
+        $userMock->shouldReceive('flushEventListeners')->andReturnNull();
+
+        $userMock->fill([
+            'name' => 'Some User',
+            'email' => 'some@website.tld',
+            'password' => 'changeme',
+        ]);
+        $userMock->reset_password_code = '12345abcde';
+        $userMock->save();
+
+        // Attempt a password reset
+        $this->assertTrue($userMock->attemptResetPassword('12345abcde', 'newpassword'));
+        $this->assertFalse($userMock->is_activated);
+    }
+}


### PR DESCRIPTION
Since the reset password flow involves an email being sent to the user to confirm the password reset, this should satisfy user activation as well as the same requirement is met.

Refs: https://github.com/wintercms/wn-user-plugin/issues/35#issuecomment-1582527947
